### PR TITLE
Clean up local tarball and backup dir after successful S3 upload. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ function sendToS3(options, directory, target, callback) {
  * sync
  *
  * Performs a mongodump on a specified database, gzips the data,
- * and uploads it to s3.
+ * and uploads it to s3. Cleans up only on successful upload.
  *
  * @param mongodbConfig   mongodb config [host, port, username, password, db]
  * @param s3Config        s3 config [key, secret, bucket]
@@ -234,7 +234,9 @@ function sync(mongodbConfig, s3Config, callback) {
     async.apply(removeRF, path.join(tmpDir, archiveName)),
     async.apply(mongoDump, mongodbConfig, tmpDir),
     async.apply(compressDirectory, tmpDir, mongodbConfig.db, archiveName),
-    async.apply(sendToS3, s3Config, tmpDir, archiveName)
+    async.apply(sendToS3, s3Config, tmpDir, archiveName),
+    async.apply(removeRF, backupDir),
+    async.apply(removeRF, path.join(tmpDir, archiveName))
   ], function(err) {
     if(err) {
       log(err, 'error');


### PR DESCRIPTION
This patch deletes the backup dir and tarball after successful S3 upload.

I attempted to clean up unconditionally, but keep running into a bizarre EPIPE error related to either asynchronous logging to stdout after process ends or related to the exec calling `rm -rf`. At least cleaning up on success is closer to the right behavior than current behavior, which will quickly fill up a filesystem for very large databases.