### PR TITLE
Server-side encryption option and clean up temp folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The file should have the following format:
         "key": "your_s3_key",
         "secret": "your_s3_secret",
         "bucket": "s3_bucket_to_upload_to",
-        "destination": "/"
+        "destination": "/",
+        "encrypt": true
       },
       "cron": {
         "time": "11:59",
@@ -48,7 +49,7 @@ you need it.
 ### Timezones
 
 The optional "timezone" allows you to specify timezone-relative time regardless
-of local timezone on the host machine. 
+of local timezone on the host machine.
 
       "cron": {
         "time": "00:00",

--- a/config.sample.json
+++ b/config.sample.json
@@ -10,7 +10,8 @@
     "key": "your_s3_key",
     "secret": "your_s3_secret",
     "bucket": "s3_bucket_to_upload_to",
-    "destination": "/"
+    "destination": "/",
+    "encrypt": true
   },
   "cron": {
     "time": "00:00"

--- a/index.js
+++ b/index.js
@@ -175,7 +175,8 @@ function sendToS3(options, directory, target, callback) {
   var knox = require('knox')
     , sourceFile = path.join(directory, target)
     , s3client
-    , destination = options.destination || '/';
+    , destination = options.destination || '/'
+    , headers = {};
 
   callback = callback || function() { };
 
@@ -185,8 +186,11 @@ function sendToS3(options, directory, target, callback) {
     bucket: options.bucket
   });
 
+  if (options.encrypt)
+    headers = {"x-amz-server-side-encryption": "AES256"}
+
   log('Attemping to upload ' + target + ' to the ' + options.bucket + ' s3 bucket');
-  s3client.putFile(sourceFile, path.join(destination, target),  function(err, res){
+  s3client.putFile(sourceFile, path.join(destination, target), headers, function(err, res){
     if(err) {
       return callback(err);
     }

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function removeRF(target, callback) {
     if (!exists) {
       return callback(null);
     }
-    log("Removing " + target, 'warn');
+    log("Removing " + target, 'info');
     exec( 'rm -rf ' + target, callback);
   });
 }

--- a/index.js
+++ b/index.js
@@ -241,7 +241,13 @@ function sync(mongodbConfig, s3Config, callback) {
     } else {
       log('Successfully backed up ' + mongodbConfig.db);
     }
-    return callback(err);
+    // remove folders even if there was an error
+    async.series([
+      async.apply(removeRF, backupDir),
+      async.apply(removeRF, path.join(tmpDir, archiveName))
+    ], function() {
+      return callback(err);
+    });
   });
 }
 


### PR DESCRIPTION
To make this module more secure, I added a couple features to my fork.
1. Clean up tmp folders after s3 upload or error (like #7 except this works after unsuccessful upload or error)
2. Add an option to use AWS server-side-encryption. All that's required is [adding a simple header to the put](http://docs.aws.amazon.com/AmazonS3/latest/dev/SSEUsingRESTAPI.html)

Tested both of these locally and they seem to work swimmingly