### PR TITLE
Allow for arbitrary knox options in s3upload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The file should have the following format:
       }
     }
 
+All options in the "s3" object, except for desination, will be directly passed to knox, therefore, you can include any of the options listed [in the knox documentation](https://github.com/LearnBoost/knox#client-creation-options "Knox README").
+
 ### Crontabs
 
 You may optionally substitute the cron "time" field with an explicit "crontab"

--- a/index.js
+++ b/index.js
@@ -179,11 +179,9 @@ function sendToS3(options, directory, target, callback) {
 
   callback = callback || function() { };
 
-  s3client = knox.createClient({
-    key: options.key,
-    secret: options.secret,
-    bucket: options.bucket
-  });
+  // Deleting destination because it's not an explicitly named knox option
+  delete options.destination;
+  s3client = knox.createClient(options);
 
   log('Attemping to upload ' + target + ' to the ' + options.bucket + ' s3 bucket');
   s3client.putFile(sourceFile, path.join(destination, target),  function(err, res){


### PR DESCRIPTION
I don't see any reason you shouldn't be able to add arbitrary knox options considering they can be passed directly in to the client creation.