### PR TITLE
Backup all database when '-d' option is not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,9 +91,13 @@ function mongoDump(options, directory, callback) {
 
   mongoOptions= [
     '-h', options.host + ':' + options.port,
-    '-d', options.db,
     '-o', directory
   ];
+
+  if(options.db) {
+    mongoOptions.push('-d');
+    mongoOptions.push(options.db);
+  }
 
   if(options.username && options.password) {
     mongoOptions.push('-u');


### PR DESCRIPTION
When '-d' option is not exist, all database should be backup.
We will be able to backup all database very simply.